### PR TITLE
chore: replace htmlstrip-native

### DIFF
--- a/dadi-dustjs-helpers.js
+++ b/dadi-dustjs-helpers.js
@@ -231,7 +231,7 @@ var ___dadiDustJsHelpers = (function (dust, options) { // eslint-disable-line
   */
   dust.helpers.htmlstrip = function (chunk, context, bodies, params) {
     return chunk.capture(bodies.block, context, function (data, chunk) {
-      data = htmlStrip.html_strip(data).trim()
+      data = htmlStrip(data).trim()
 
       chunk.write(data)
       chunk.end()

--- a/dadi-dustjs-helpers.js
+++ b/dadi-dustjs-helpers.js
@@ -6,7 +6,7 @@ var ___dadiDustJsHelpers = (function (dust, options) { // eslint-disable-line
     var pluralist = require('pluralist')
     var _ = require('underscore')
     var s = require('underscore.string')
-    var htmlStrip = require('htmlstrip-native')
+    var htmlStrip = require('striptags')
   }
 
   dust.webExtensions = options || {}
@@ -231,13 +231,7 @@ var ___dadiDustJsHelpers = (function (dust, options) { // eslint-disable-line
   */
   dust.helpers.htmlstrip = function (chunk, context, bodies, params) {
     return chunk.capture(bodies.block, context, function (data, chunk) {
-      var options = {
-        include_script: false, // exclude the content of <script> tags
-        include_style: false, // exclude the content of <style> tags
-        compact_whitespace: false // compact consecutive '\s' whitespace into single char
-      }
-
-      data = htmlStrip.html_strip(data, options).trim()
+      data = htmlStrip.html_strip(data).trim()
 
       chunk.write(data)
       chunk.end()

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
   },
   "homepage": "https://github.com/dadi/dustjs-helpers#readme",
   "dependencies": {
-    "htmlstrip-native": "^0.1.3",
     "json5": "^0.5.0",
     "marked": "^0.3.5",
     "moment": "^2.13.0",
     "pluralist": "^1.0.4",
+    "snyk": "^1.34.1",
+    "striptags": "^3.1.0",
     "underscore": "^1.8.3",
-    "underscore.string": "^3.3.4",
-    "snyk": "^1.34.1"
+    "underscore.string": "^3.3.4"
   },
   "devDependencies": {
     "dustjs-linkedin": "^2.7.2",


### PR DESCRIPTION
htmlstrip-native is an old Python port